### PR TITLE
[IN-98] llm 통신 수정사항 반영(레시피 추천의 근거)

### DIFF
--- a/backend/src/main/java/org/example/capstonenewri/Dto/ResponseRecipeDto.java
+++ b/backend/src/main/java/org/example/capstonenewri/Dto/ResponseRecipeDto.java
@@ -9,20 +9,52 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 public class ResponseRecipeDto {
-    private String rcp_nm;
-    private String att_file_no_main;
     private String message;
 
-    @Builder
-    public ResponseRecipeDto(String rcp_nm, String att_file_no_main, String message){
-        this.rcp_nm = rcp_nm;
-        this.att_file_no_main = att_file_no_main;
-        this.message = message;
-    }
+    private Long id;
+    private String rcp_nm;
+    private String att_file_no_main;
+    private String rcp_parts_dtls;
+    private String rcp_na_tip;
+    private String manual01;
+    private String manual02;
+    private String manual03;
+    private String manual04;
+    private String manual05;
+    private String manual06;
+    private String manual_img01;
+    private String manual_img02;
+    private String manual_img03;
+    private String manual_img04;
+    private String manual_img05;
+    private String manual_img06;
+    private String rcp_pat2;
+    private String rcp_way2;
 
-    public ResponseRecipeDto(String rcp_nm, String att_file_no_main) {
+    public ResponseRecipeDto(Long id,String rcp_nm, String att_file_no_main, String rcp_parts_dtls, String rcp_na_tip,
+                             String manual01, String manual02, String manual03, String manual04, String manual05, String manual06,
+                             String manual_img01, String manual_img02, String manual_img03, String manual_img04, String manual_img05,
+                             String manual_img06, String rcp_pat2, String rcp_way2) {
+        this.id = id;
         this.rcp_nm = rcp_nm;
         this.att_file_no_main = att_file_no_main;
+        this.rcp_parts_dtls = rcp_parts_dtls;
+        this.rcp_na_tip = rcp_na_tip;
+        this.manual01 = manual01;
+        this.manual02 = manual02;
+        this.manual03 = manual03;
+        this.manual04 = manual04;
+        this.manual05 = manual05;
+        this.manual06 = manual06;
+        this.manual_img01 = manual_img01;
+        this.manual_img02 = manual_img02;
+        this.manual_img03 = manual_img03;
+        this.manual_img04 = manual_img04;
+        this.manual_img05 = manual_img05;
+        this.manual_img06 = manual_img06;
+        this.rcp_pat2 = rcp_pat2;
+        this.rcp_way2 = rcp_way2;
+
     }
 
     public ResponseRecipeDto(String message) {

--- a/backend/src/main/java/org/example/capstonenewri/Dto/ResponseRecipeRecommendationDto.java
+++ b/backend/src/main/java/org/example/capstonenewri/Dto/ResponseRecipeRecommendationDto.java
@@ -10,5 +10,15 @@ import java.util.List;
 @Setter
 @NoArgsConstructor
 public class ResponseRecipeRecommendationDto {
-    private List<Long> recipes;
+    private List<RecipeDetail> recipes;
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    public static class RecipeDetail{
+        private Long row;
+        private String recipe_parts_dtls;
+        private String recipe_na_tip;
+
+    }
 }

--- a/backend/src/main/java/org/example/capstonenewri/Entity/Converter/RecipeListConverter.java
+++ b/backend/src/main/java/org/example/capstonenewri/Entity/Converter/RecipeListConverter.java
@@ -4,17 +4,18 @@ import jakarta.persistence.AttributeConverter;
 import jakarta.persistence.Converter;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.example.capstonenewri.Dto.ResponseRecipeRecommendationDto;
 
 import java.util.List;
 import java.io.IOException;
 
 @Converter
-public class RecipeListConverter implements AttributeConverter<List<Long>, String> {
+public class RecipeListConverter implements AttributeConverter<List<ResponseRecipeRecommendationDto.RecipeDetail>, String> {
 
     private final static ObjectMapper objectMapper = new ObjectMapper();
 
     @Override
-    public String convertToDatabaseColumn(List<Long> attribute) {
+    public String convertToDatabaseColumn(List<ResponseRecipeRecommendationDto.RecipeDetail> attribute) {
         try {
             return objectMapper.writeValueAsString(attribute);
         } catch (IOException e) {
@@ -23,9 +24,9 @@ public class RecipeListConverter implements AttributeConverter<List<Long>, Strin
     }
 
     @Override
-    public List<Long> convertToEntityAttribute(String dbData) {
+    public List<ResponseRecipeRecommendationDto.RecipeDetail> convertToEntityAttribute(String dbData) {
         try {
-            return objectMapper.readValue(dbData, new TypeReference<List<Long>>(){});
+            return objectMapper.readValue(dbData, new TypeReference<List<ResponseRecipeRecommendationDto.RecipeDetail>>(){});
         } catch (IOException e) {
             throw new RuntimeException("JSON reading error", e);
         }

--- a/backend/src/main/java/org/example/capstonenewri/Entity/DayDiary.java
+++ b/backend/src/main/java/org/example/capstonenewri/Entity/DayDiary.java
@@ -2,6 +2,8 @@ package org.example.capstonenewri.Entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.example.capstonenewri.Dto.ResponseRecipeDto;
+import org.example.capstonenewri.Dto.ResponseRecipeRecommendationDto;
 import org.example.capstonenewri.Entity.Converter.RecipeListConverter;
 
 import java.math.BigDecimal;
@@ -52,7 +54,8 @@ public class DayDiary {
     private LocalDate date;
 
     @Convert(converter = RecipeListConverter.class)
-    private List<Long> recipes;
+    @Column(length = 40000)
+    private List<ResponseRecipeRecommendationDto.RecipeDetail> recipes;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")  // Member 테이블의 member_id를 참조
@@ -84,7 +87,7 @@ public class DayDiary {
     public void addTrans_fatty_acids_gram(BigDecimal trans_fatty_acids_gram) { this.trans_fatty_acids_gram = this.trans_fatty_acids_gram.add(trans_fatty_acids_gram); }
 
     public void setFeedback(String feedback) { this.feedback = feedback; }
-    public void setRecipes(List<Long> recipes) { this.recipes = recipes; }
+    public void setRecipes(List<ResponseRecipeRecommendationDto.RecipeDetail> recipes) { this.recipes = recipes; }
 
 
 }

--- a/backend/src/main/java/org/example/capstonenewri/Repository/RecipeRepository.java
+++ b/backend/src/main/java/org/example/capstonenewri/Repository/RecipeRepository.java
@@ -7,12 +7,17 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface RecipeRepository extends JpaRepository<Recipe, Long> {
     @Query("""
-         select new org.example.capstonenewri.Dto.ResponseRecipeDto(r.rcp_nm, r.att_file_no_main)
+         select new org.example.capstonenewri.Dto.ResponseRecipeDto(r.id, r.rcp_nm, r.att_file_no_main, r.rcp_parts_dtls, r.rcp_na_tip,
+         r.manual01, r.manual02, r.manual03, r.manual04, r.manual05, r.manual06,
+         r.manual_img01, r.manual_img02, r.manual_img03, r.manual_img04, r.manual_img05, r.manual_img06,
+         r.rcp_pat2, r.rcp_way2)
          from Recipe r
-         where r.id = :id
+         where r.id IN :ids
     """)
-    public ResponseRecipeDto findRecipeById(@Param("id") Long id);
+    public List<ResponseRecipeDto> findRecipesByIds(@Param("ids") List<Long> ids);
 }

--- a/backend/src/main/java/org/example/capstonenewri/Service/RecipeServiceImpl.java
+++ b/backend/src/main/java/org/example/capstonenewri/Service/RecipeServiceImpl.java
@@ -2,6 +2,7 @@ package org.example.capstonenewri.Service;
 
 import lombok.RequiredArgsConstructor;
 import org.example.capstonenewri.Dto.ResponseRecipeDto;
+import org.example.capstonenewri.Dto.ResponseRecipeRecommendationDto;
 import org.example.capstonenewri.Entity.DayDiary;
 import org.example.capstonenewri.Entity.Member;
 import org.example.capstonenewri.Repository.DayDiaryRepository;
@@ -16,6 +17,7 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 @Transactional
@@ -36,29 +38,62 @@ public class RecipeServiceImpl implements RecipeService{
         }
         Optional<DayDiary> dayDiaryOptional = dayDiaryRepository.findByMemberAndDate(memberOptional.get(), date);
         if (!dayDiaryOptional.isPresent()) { // 오류처리
-           List<ResponseRecipeDto> response = new ArrayList<>();
-           response.add(new ResponseRecipeDto("No Record"));
-           return ResponseEntity.status(HttpStatus.OK).body(response);
+            List<ResponseRecipeDto> response = new ArrayList<>();
+            response.add(new ResponseRecipeDto("No Record"));
+            return ResponseEntity.status(HttpStatus.OK).body(response);
         }
 
-        List<Long> recipes = dayDiaryOptional.get().getRecipes(); // daydiary의 레시피 필드
-        System.out.println("recipes = " + recipes); // 디버깅 문구
+        List<ResponseRecipeDto> recipes = findRecipesByIds(dayDiaryOptional.get().getRecipes());
+        return ResponseEntity.ok(recipes);
+    }
 
-        List<ResponseRecipeDto> responseRecipeDtoList = new ArrayList<>();
-        for (Long recipeId : recipes){
-            ResponseRecipeDto recipeDto = recipeRepository.findRecipeById(recipeId);
-            if (recipeDto == null){
-                responseRecipeDtoList.add(new ResponseRecipeDto("Recipe Not Found for ID: " + recipeId));
-            }else{
-                recipeDto.setMessage("Recipe Found");
-                responseRecipeDtoList.add(recipeDto);
-            }
+    private List<ResponseRecipeDto> findRecipesByIds(List<ResponseRecipeRecommendationDto.RecipeDetail> recipeDetails){
+        List<Long> recipeIds = recipeDetails.stream()
+                .map(ResponseRecipeRecommendationDto.RecipeDetail::getRow)
+                .collect(Collectors.toList());
+        System.out.println("recipes = " + recipeIds.toString()); // 디버깅 문구
+
+        List<ResponseRecipeDto> recipes = recipeRepository.findRecipesByIds(recipeIds);
+        if (recipes.isEmpty()) {
+            return List.of(new ResponseRecipeDto("No Recipe Found"));
         }
 
-        if (responseRecipeDtoList.isEmpty()){
-            responseRecipeDtoList.add(new ResponseRecipeDto("No Recipes Found"));
-        }
+        // 데이터 강조 로직
+        recipes.forEach(recipe -> {
+            // Null 체크 및 빈 문자열 대입
+            recipe.setAtt_file_no_main(Optional.ofNullable(recipe.getAtt_file_no_main()).orElse(""));
+            recipe.setRcp_parts_dtls(Optional.ofNullable(recipe.getRcp_parts_dtls()).orElse(""));
+            recipe.setRcp_na_tip(Optional.ofNullable(recipe.getRcp_na_tip()).orElse(""));
+            recipe.setManual01(Optional.ofNullable(recipe.getManual01()).orElse(""));
+            recipe.setManual02(Optional.ofNullable(recipe.getManual02()).orElse(""));
+            recipe.setManual03(Optional.ofNullable(recipe.getManual03()).orElse(""));
+            recipe.setManual04(Optional.ofNullable(recipe.getManual04()).orElse(""));
+            recipe.setManual05(Optional.ofNullable(recipe.getManual05()).orElse(""));
+            recipe.setManual06(Optional.ofNullable(recipe.getManual06()).orElse(""));
+            recipe.setManual_img01(Optional.ofNullable(recipe.getManual_img01()).orElse(""));
+            recipe.setManual_img02(Optional.ofNullable(recipe.getManual_img02()).orElse(""));
+            recipe.setManual_img03(Optional.ofNullable(recipe.getManual_img03()).orElse(""));
+            recipe.setManual_img04(Optional.ofNullable(recipe.getManual_img04()).orElse(""));
+            recipe.setManual_img05(Optional.ofNullable(recipe.getManual_img05()).orElse(""));
+            recipe.setManual_img06(Optional.ofNullable(recipe.getManual_img06()).orElse(""));
+            recipe.setRcp_pat2(Optional.ofNullable(recipe.getRcp_pat2()).orElse(""));
+            recipe.setRcp_way2(Optional.ofNullable(recipe.getRcp_way2()).orElse(""));
 
-        return ResponseEntity.ok(responseRecipeDtoList);
+            recipeDetails.stream()
+                    .filter(detail -> detail.getRow().equals(recipe.getId()))
+                    .findFirst()
+                    .ifPresent(detail ->{
+                        if(!detail.getRecipe_parts_dtls().isEmpty() && !recipe.getRcp_parts_dtls().isEmpty() && recipe.getRcp_parts_dtls().contains(detail.getRecipe_parts_dtls())){
+                            String emphasizedText = "==" + detail.getRecipe_parts_dtls() + "==";
+                            recipe.setRcp_parts_dtls(recipe.getRcp_parts_dtls().replace(detail.getRecipe_parts_dtls(), emphasizedText));
+                        }
+                        if(!detail.getRecipe_na_tip().isEmpty() &&!recipe.getRcp_na_tip().isEmpty() && recipe.getRcp_na_tip().contains(detail.getRecipe_na_tip())){
+                            String emphasizedText = "==" + detail.getRecipe_na_tip() + "==";
+                            recipe.setRcp_na_tip(recipe.getRcp_na_tip().replace(detail.getRecipe_na_tip(), emphasizedText));
+                        }
+                    });
+            recipe.setMessage("Recipe Found");
+        });
+        return recipes;
     }
 }


### PR DESCRIPTION
- ResponseRecipeRecommendationDto.java : 필드 변경
- DayDiary.java : recipes 필드 형식 변경 (Long -> ResponseRecipeRecommendationDto.RecipeDetail)
- RecipeListConverter.java 변경

<api/recipe/{date}> 관련 사항
- RecipeServiceImpl.java : 데이터 변경에 따른 필드 조회 방법 변경
- RecipeRepository.java : DB 쿼리 날리는 횟수를 줄이기 위해 id 배열로 한꺼번에 조회하는 것으로 로직 수정

[IN-86] api/recipe/{date} 개발

db 접근을 최소화하기위해 각 레시피에 대한 데이터 필드를 한번에 넘겨주기로 상의 후 결정했다. 일단 이 커밋엔 rcp_parts_dtls, rcp_na_tip 강조 로직을 구현하였다.

- RecipeRepository.java : jpql 수정
- RecipeServiceImpl.java : 강조할 데이터 존재 여부, 레시피 테이블 칼럼 value 존재 여부에 따라 강조
- ResponseRecipeDto.java : 넘겨줄 데이터 추가

[IN-86] api/recipe/{date} 개발

- ResponseRecipeDto.java : manual01~manual06 manual_img01~06
rcp_pat2
rcp_way2
필드 추가

- RecipeRepository.java : dto 에 맞게 jpql 수정
- RecipeServiceImpl.java : 반복문 안에서 필드가 null이면 빈 문자열 처리 추가